### PR TITLE
hotfix: persistir ctwa_clid do referral CTWA em additional_attributes

### DIFF
--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -8,8 +8,28 @@ module Whatsapp::IncomingMessageServiceHelpers
       account_id: @inbox.account_id,
       inbox_id: @inbox.id,
       contact_id: @contact.id,
-      contact_inbox_id: @contact_inbox.id
+      contact_inbox_id: @contact_inbox.id,
+      additional_attributes: ctwa_referral_attributes
     }
+  end
+
+  # Persiste o referral de anúncios Click-to-WhatsApp (inclui ctwa_clid) nos
+  # additional_attributes da conversa, para atribuição via Meta Conversions API.
+  # Retorna {} quando não há referral — comportamento idêntico ao anterior.
+  def ctwa_referral_attributes
+    referral = @processed_params[:messages]&.first&.dig(:referral)
+    return {} if referral.blank?
+
+    {
+      ctwa_clid: referral[:ctwa_clid],
+      referral_source_id: referral[:source_id],
+      referral_source_type: referral[:source_type],
+      referral_source_url: referral[:source_url],
+      referral_headline: referral[:headline]
+    }.compact
+  rescue StandardError => e
+    Rails.logger.warn "CTWA referral parse failed: #{e.message}"
+    {}
   end
 
   def processed_params


### PR DESCRIPTION
## Problema

Anúncios **Click-to-WhatsApp (CTWA)** entregam o `ctwa_clid` (Click ID, único por clique) dentro do objeto `referral` da **primeira mensagem** do webhook da WhatsApp Cloud API. Esse ID é o que permite atribuir uma conversão (ex: desembolso de empréstimo) de volta ao anúncio via **Meta Conversions API**.

Hoje o Chatwoot **descarta o `referral` por completo** — auditoria no banco mostrou zero `ctwa_clid` em `messages`, `conversations` e `contacts`. Sem ele, a atribuição de campanhas CTWA é impossível.

## Mudança

Em `Whatsapp::IncomingMessageServiceHelpers#conversation_params`, ao criar a conversa, persistimos o `referral` em `conversation.additional_attributes`:

- `ctwa_clid`
- `referral_source_id` (id do anúncio)
- `referral_source_type`
- `referral_source_url`
- `referral_headline`

## Segurança / blast radius

- Só **adiciona** dados; nenhum fluxo de mensagem é alterado.
- Sem referral → retorna `{}` (idêntico ao comportamento atual).
- `rescue StandardError` blinda contra payloads inesperados: se o parse falhar, loga e segue com `{}` — nenhuma mensagem deixa de ser processada.
- Aplica-se apenas a conversas novas (ponto de criação), que é exatamente onde o clique CTWA inicia o contato.

## Consumo

O Aurea Sys lê `conversations.additional_attributes->>'ctwa_clid'` por `contact_id` na criação do RASCUNHO e o reenvia nos eventos `LeadSubmitted`/`Purchase` da Conversions API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
